### PR TITLE
For Commands `version` and `help`

### DIFF
--- a/name_subject_to_change/cli/main.py
+++ b/name_subject_to_change/cli/main.py
@@ -1,47 +1,30 @@
 import typer
 
-__version__ = "0.1.0"
+__version__ = "0.0.1"
 
-app = typer.Typer(no_args_is_help=True, help=f"ZAQ - Version: {__version__}")
-
-
-def vers(value: bool):
-    """
-    Report current version of ZAQ - Version Control System package.
-    :param value: bool
-    """
-    if value:
-        typer.echo(f"ZAQ Version: {__version__}")
-        raise typer.Exit()
+app = typer.Typer(
+    name="zaq",
+    no_args_is_help=True,
+    add_completion=False,
+    invoke_without_command=True,
+    help=f"ZAQ: Version Control System. \n\nVersion: {__version__}",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 
 
 @app.callback(invoke_without_command=True)
-def app_callback():
-    """
-    Report current version of ZAQ - Version Control System package.
-    :return:
-    """
-    typer.echo(f"ZAQ Version: {__version__}")
-    raise typer.Exit()
-
-
-@app.command()
-def zaq():
-    print(f"Zaq is the temporary name of this project.")
-
-
-@app.callback()
-def main(
-        version: bool = typer.Option(
-            None,
-            "-v",
-            "--version",
-            callback=app_callback,
-            is_eager=True,
-            help="Report current version of zaq package.",
-        )
-):
-    return
+def get_version(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-v",
+        help="Print version and exit.",
+    ),
+) -> None:
+    """Display the version."""
+    if version:
+        typer.echo(f"ZAQ Version: {__version__}")
+        raise typer.Exit()
 
 
 if __name__ == "__main__":

--- a/name_subject_to_change/cli/main.py
+++ b/name_subject_to_change/cli/main.py
@@ -21,7 +21,9 @@ def get_version(
         help="Print version and exit.",
     ),
 ) -> None:
-    """Display the version."""
+    """
+    Display the version of ZAQ - Version Control System.
+    """
     if version:
         typer.echo(f"ZAQ Version: {__version__}")
         raise typer.Exit()

--- a/name_subject_to_change/cli/main.py
+++ b/name_subject_to_change/cli/main.py
@@ -1,35 +1,47 @@
 import typer
 
-app = typer.Typer()
+__version__ = "0.1.0"
+
+app = typer.Typer(no_args_is_help=True, help=f"ZAQ - Version: {__version__}")
 
 
-def version_callback(value: bool):
+def vers(value: bool):
     """
     Report current version of ZAQ - Version Control System package.
+    :param value: bool
     """
-    __version__ = "0.1.0"
     if value:
         typer.echo(f"ZAQ Version: {__version__}")
         raise typer.Exit()
 
 
-@app.callback()
-def main(
-    version: bool = typer.Option(
-        None,
-        "-v",
-        "--version",
-        callback=version_callback,
-        is_eager=True,
-        help="Report current version of zaq package.",
-    )
-):
-    return
+@app.callback(invoke_without_command=True)
+def app_callback():
+    """
+    Report current version of ZAQ - Version Control System package.
+    :return:
+    """
+    typer.echo(f"ZAQ Version: {__version__}")
+    raise typer.Exit()
 
 
 @app.command()
 def zaq():
     print(f"Zaq is the temporary name of this project.")
+
+
+@app.callback()
+def main(
+        version: bool = typer.Option(
+            None,
+            "-v",
+            "--version",
+            callback=app_callback,
+            is_eager=True,
+            help="Report current version of zaq package.",
+        )
+):
+    return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* version can be shown now, using `-v | --version`
* help message is invoked by default 
* **Bonus**: Help message shows version to when invoked without argument.

Completed #1 and working on #2